### PR TITLE
Convert serverless function to edge function to test longer timeout

### DIFF
--- a/src/app/api/generate/sound/route.ts
+++ b/src/app/api/generate/sound/route.ts
@@ -1,11 +1,14 @@
 import { generateSound } from "@/lib/generateSound";
 import { NextRequest, NextResponse } from "next/server";
 
+export const config = {
+  runtime: "edge",
+};
+
 export async function POST(req: NextRequest) {
   const { caption } = await req.json();
 
   const output = await generateSound(caption);
-  console.log(output);
 
   return NextResponse.json({ output });
 }


### PR DESCRIPTION
This is just a test to see if converting the function from a serverless functions to a edge functions will allow us to bypass the 10 second timeout for vercel serverless functions.