### PR TITLE
Replace deprecated config object

### DIFF
--- a/src/app/api/generate/sound/route.ts
+++ b/src/app/api/generate/sound/route.ts
@@ -1,9 +1,7 @@
 import { generateSound } from "@/lib/generateSound";
 import { NextRequest, NextResponse } from "next/server";
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
   const { caption } = await req.json();


### PR DESCRIPTION
Replaced `export const config=…` with the following: `export const runtime = "edge"`


