### PR TITLE
fix casing

### DIFF
--- a/src/components/design/TakePhotoButton.tsx
+++ b/src/components/design/TakePhotoButton.tsx
@@ -55,7 +55,7 @@ export default function TakePhotoButton() {
           aria-hidden
           className="relative z-10 ml-auto mt-auto h-16 w-16 overflow-hidden"
         >
-          <Image src="/images/assets/camera.png" fill={true} alt="Image icon" />
+          <Image src="/images/assets/Camera.png" fill={true} alt="Image icon" />
         </div>
         <div
           aria-hidden


### PR DESCRIPTION
In this pr, I have changed "camera.png" to "Camera.png" to match the casing of the filename in the assets folder.